### PR TITLE
attempting to fix left_join error 

### DIFF
--- a/R/process.R
+++ b/R/process.R
@@ -55,7 +55,8 @@ scale_factors <- function(x) {
 }
 
 ceiling <- function(x, obs) {
-  x %>%
+  x %>% 
+  mutate(level = factor(level, orderd = FALSE)) %>%
   mutate(
     rescale_postS =
       level == 'postS' &


### PR DESCRIPTION
issues is thrown for left_join on scale_factor(obs) between ordered and unordered factor for ceiling function